### PR TITLE
fix: disable the kitty keyboard protocol on exit

### DIFF
--- a/standalone/src/main.rs
+++ b/standalone/src/main.rs
@@ -13,7 +13,7 @@ use std::{
 use grainiac_core::Sampler;
 use jack::{AudioIn, AudioOut, Client, ClientOptions, MidiIn, Port};
 use ratatui::crossterm::{
-    event::{KeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+    event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
     execute,
 };
 
@@ -263,6 +263,7 @@ fn main() -> io::Result<()> {
     }
 
     ratatui::restore();
+    execute!(stdout, PopKeyboardEnhancementFlags);
 
     Ok(())
 }


### PR DESCRIPTION
I realized this while reading the code - as stated [in the docs](https://docs.rs/crossterm/latest/crossterm/event/struct.PushKeyboardEnhancementFlags.html), the keyboard protocol should be disabled on exit for properly restoring the terminal state.

> It should be paired with PopKeyboardEnhancementFlags at the end of execution.
